### PR TITLE
gstdevice: Fetch device provider from message source

### DIFF
--- a/subprojects/gstreamer/gst/gstdevicemonitor.c
+++ b/subprojects/gstreamer/gst/gstdevicemonitor.c
@@ -277,9 +277,8 @@ bus_sync_message (GstBus * bus, GstMessage * message,
       gst_message_parse_device_changed (message, &device, NULL);
 
     GST_OBJECT_LOCK (monitor);
-    provider =
-        GST_DEVICE_PROVIDER (gst_object_get_parent (GST_OBJECT (device)));
-    if (is_provider_hidden (monitor, monitor->priv->hidden, provider)) {
+    provider = GST_DEVICE_PROVIDER (GST_MESSAGE_SRC (message));
+    if (provider && is_provider_hidden (monitor, monitor->priv->hidden, provider)) {
       matches = FALSE;
     } else {
       guint i;
@@ -299,7 +298,6 @@ bus_sync_message (GstBus * bus, GstMessage * message,
     }
     GST_OBJECT_UNLOCK (monitor);
 
-    gst_object_unref (provider);
     gst_object_unref (device);
 
     if (matches)


### PR DESCRIPTION
The GstDevice removed may not have a parent anymore when we check whether the provider is hidden. Let's fetch the provider from the message source, which is more reliable.

Fixes a racy nullptr deref on macOS when a device is unplugged:

```
libgstreamer-1.0.0.dylib!is_provider_hidden (gstreamer/subprojects/gstreamer/gst/gstdevicemonitor.c:240)
libgstreamer-1.0.0.dylib!bus_sync_message (gstreamer/subprojects/gstreamer/gst/gstdevicemonitor.c:286)
libgstreamer-1.0.0.dylib!gst_bus_post (gstreamer/subprojects/gstreamer/gst/gstbus.c:358)
libgstreamer-1.0.0.dylib!gst_device_provider_device_remove (gstreamer/subprojects/gstreamer/gst/gstdeviceprovider.c:685)
libgstosxaudio.dylib!gst_osx_audio_device_provider_update_devices ([...]/sys/osxaudio/gstosxaudiodeviceprovider.c:539)
libgstosxaudio.dylib!_audio_devices_changed_cb ([...]/sys/osxaudio/gstosxaudiodeviceprovider.c:313)
CoreAudio!HALObject::PropertiesChanged(unsigned int, AudioObjectPropertyAddress const*) (Unknown Source:0)
CoreAudio!HALSystem::PropertiesChanged(unsigned int, AudioObjectPropertyAddress const*) (Unknown Source:0)
CoreAudio!HALSystem::ObjectsPublishedAndDied(...) (Unknown Source:0)
CoreAudio!HALSystem::AudioObjectsPublishedAndDied(...) (Unknown Source:0)
CoreAudio!HALC_ShellPlugIn::ReconcileDeviceList(bool, bool) (Unknown Source:0)
CoreAudio!HALC_ShellPlugIn::CreateAggregateDevice(__CFDictionary const*, unsigned int&) (Unknown Source:0)
CoreAudio!AudioHardwareCreateAggregateDevice_mac_imp (Unknown Source:0)
AudioDSP!___lldb_unnamed_symbol15046 (Unknown Source:0)
AudioDSP!___lldb_unnamed_symbol15038 (Unknown Source:0)
AudioDSP!___lldb_unnamed_symbol33307 (Unknown Source:0)
AudioToolboxCore!APComponent::newInstance(...) (Unknown Source:0)
AudioToolboxCore!instantiate(...) (Unknown Source:0)
AudioToolboxCore!__AudioComponentInstanceNew_block_invoke (Unknown Source:0)
AudioToolboxCore!Synchronously (Unknown Source:0)
```