### PR TITLE
[REMT-9043] Reset downstream_ret after flush

### DIFF
--- a/subprojects/gst-plugins-bad/sys/applemedia/vtdec.c
+++ b/subprojects/gst-plugins-bad/sys/applemedia/vtdec.c
@@ -807,6 +807,8 @@ gst_vtdec_sink_event (GstVideoDecoder * decoder, GstEvent * event)
       g_mutex_lock (&vtdec->queue_mutex);
       vtdec->is_flushing = FALSE;
       g_mutex_unlock (&vtdec->queue_mutex);
+
+      vtdec->downstream_ret = GST_FLOW_OK;
       break;
     default:
       break;


### PR DESCRIPTION
Reset downstream_ret so that handle_frame() restarts the output loop instead of dropping frames.

Without this change, after a flush the output loop stays paused and downstream_ret remains GST_FLOW_FLUSHING, causing all subsequent frames to be dropped.